### PR TITLE
add .gitattibute to keep the linux formated eof, whatever the OS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Files with Unix line endings
+*.py  text eol=lf
+*.sh  text eol=lf
+*.md  text eol=lf
+
+# Files with native line endings
+*.html  text
+*.md    text
+
+# Binary files


### PR DESCRIPTION
I did fork from your repository a while ago. 
Lately, I made a git from your repository to my local copy to get the latest changes, in particular the commit "Behave on FW 5.12+" ...
I then copy paste the files to my Kindle...
To cut a long story short, end of line was changed from LF to CRLF, preventing the Python file to execute on the kindle...
This .gitattribute file should prevent the behavior and force the unix stream formatted files on the local repository AND on my GitHub repository...
Thanks NiLuje to maintain this...